### PR TITLE
Add assertion for lists

### DIFF
--- a/tests/DataProvider/ArrayDataProvider.php
+++ b/tests/DataProvider/ArrayDataProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\DataProvider;
+
+class ArrayDataProvider
+{
+    public static function listArray(): array
+    {
+        return [
+            'ordered_same_items' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', '3', 4, 'yavari'],
+            ],
+            'ordered_one_different_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', '3', 4, 'another'],
+            ],
+            'ordered_with_extra_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', '3', 4, 'yavari', 'newOne'],
+            ],
+            'ordered_with_less_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', '3', 4],
+            ],
+            'ordered_with_false_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', '3', 4, false],
+            ],
+            'ordered_with_true_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', '3', 4, true],
+            ],
+            'not_ordered_same_items' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', 'yavari', 4, '3'],
+            ],
+            'not_ordered_one_different_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', 'another', 4, '3'],
+            ],
+            'not_ordered_with_extra_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', 'newOne', 'yavari', 4, '3'],
+            ],
+            'not_ordered_with_less_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', 4, '3'],
+            ],
+            'not_ordered_with_false_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', false, 4, '3'],
+            ],
+            'not_ordered_with_true_item' => [
+                'arr1' => ['ali', '3', 4, 'yavari'],
+                'arr2' => ['ali', true, 4, '3'],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/ArrayTest.php
+++ b/tests/Unit/ArrayTest.php
@@ -2,12 +2,24 @@
 
 namespace Tests\Unit;
 
+use PHPUnit\Framework\Attributes\DataProviderExternal;
+use Tests\DataProvider\ArrayDataProvider;
 use Tests\TestCase;
 
 class ArrayTest extends TestCase
 {
-    public function test_new(): void
+    #[DataProviderExternal(ArrayDataProvider::class, 'listArray')]
+    public function test_list_order_matter($arr1, $arr2): void
     {
-        $this->assertTrue(true);
+        $this->assertSame($arr1, $arr2);
+    }
+
+    #[DataProviderExternal(ArrayDataProvider::class, 'listArray')]
+    public function test_list_order_not_matter($arr1, $arr2): void
+    {
+        sort($arr1);
+        sort($arr2);
+        
+        $this->assertSame($arr1, $arr2);
     }
 }


### PR DESCRIPTION
In these examples, we can assert lists in PHPUnit in two different conditions. First order of list is matter and second the order of list in not matter.